### PR TITLE
Abort transition when a new command is sent, allow transitions to be float and set add ability for default off

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Configuration variables:
 - **universe** (*Optional; default=0*): Art-Net universe for these DMX channels
 - **dmx_channels** (*Optional; default=512*): The number of DMX channels to send a value for (even number between 2 & 512)
 - **default_level** (*Optional; default=255*): Default level for Home Assistant to assume all lights have been set to - in most cases 0 would make sense. Note Home Assistant will not send these values to the gateway until an explicit change is made unless send_levels_on_startup is True.
-- **default_type** (*Optional; default=dimmer*): specify the default type for devices that have not specified a type
+- **default_off** (*Optional; default=True*): Whether Home Assistant should assume the device is off by default. See *default_level*.
+- **default_type** (*Optional; default=dimmer*): Specify the default type for devices that have not specified a type
 - **send_levels_on_startup** (*Optional; default=True*): Setting this to False means Home Assistant will not send any DMX frames until a change is made.
 
 Device configuration variables:
@@ -91,6 +92,7 @@ Device configuration variables:
   - **'switch'** (single channel 0 or 255)
   - **'custom_white'** (configure dimmer and temperature in any required channel order)
 - **default_level** (*Optional; default=255*): Default level to assume the light is set to (0-255). 
+- **default_off** (*Optional; default=True*): Whether Home Assistant should assume the device is off by default. See *default_level*.
 - **channel_setup** (*Optional; for custom_white lights*): String to define channel layout where:
   - d = dimmer (brightness 0 to 255)
   - t = temperature (0 = warm, 255 = cold)
@@ -101,7 +103,7 @@ Device configuration variables:
 Please use [light_profiles.csv](https://www.home-assistant.io/components/light/#default-turn-on-values) if you want to specify a default colour or brightness to be used when turning the light on in HA.
 - **default_rgb** (*Optional*): Default colour to give to Home Assistant for the light in the format [R,G,B]
 - **white_level** (*Optional*): Default white level for RGBW lights (0-255)
-- **transition** (*Optional*): Set a default fade time for transitions. Transition times specified through the turn_on / turn_off service calls in Home Assistant will override this behaviour. 
+- **transition** (*Optional*): Set a default fade time in seconds for transitions. Can be a decimal number. Transition times specified through the turn_on / turn_off service calls in Home Assistant will override this behaviour. 
 
 To enable debug logging for this component:
 

--- a/custom_components/dmx/light.py
+++ b/custom_components/dmx/light.py
@@ -140,7 +140,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional(CONF_DEFAULT_COLOR): vol.All(
                 vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                 vol.Coerce(tuple)),
-            vol.Optional(CONF_TRANSITION, default=0): vol.All(vol.Coerce(int),
+            vol.Optional(CONF_TRANSITION, default=0): vol.All(vol.Coerce(float),
                                                               vol.Range(min=0,
                                                               max=60)),
             vol.Optional(CONF_CHANNEL_SETUP): cv.string,


### PR DESCRIPTION
When transitioning a device, a new command should abort this previous transition to avoid switching back to the transitioning state.
Transitions should also be float to allow for transitions less than 1 second. Home Assistant supports transitions < 1, and so should the config.
Currently the devices can only be set to default to value 0, which sets the brightness to 0, but the state of the entity is still on. With this new `default_off` config field it is set to the off state, and can be then switched on without the brightness being 0.