### PR TITLE
Allow maximum transition time of 3600 seconds

### DIFF
--- a/custom_components/dmx/light.py
+++ b/custom_components/dmx/light.py
@@ -176,7 +176,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                 vol.Coerce(tuple)),
             vol.Optional(CONF_TRANSITION, default=0): vol.All(vol.Coerce(float),
                                                               vol.Range(min=0,
-                                                              max=60)),
+                                                              max=3600)),
             vol.Optional(CONF_CHANNEL_SETUP): cv.string,
         }
     ]),


### PR DESCRIPTION
I am using this component for controlling my aquarium and simulate a slow sunrise/sunset. They take longer than the currently allowed 60 seconds - and I don't see a reason that the limit really needs to be that low.